### PR TITLE
Fix UDP discovery.

### DIFF
--- a/app/src/main/java/cz/mendelu/xmarik/train_manager/MainActivity.java
+++ b/app/src/main/java/cz/mendelu/xmarik/train_manager/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
@@ -122,10 +123,8 @@ public class MainActivity extends AppCompatActivity
                         ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
                         NetworkInfo mWifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
                         if (mWifi.isConnected()) {
-                            UdpDiscover udp = new UdpDiscover(context, port, (MainActivity) obj);
+                            new UdpDiscover(context, port, (MainActivity) obj).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, null);
                             System.out.print("button activated");
-                            //udp.run();
-                            udp.execute();
                             float deg = lButton.getRotation() + 720F;
                             lButton.animate().rotation(deg).setInterpolator(new AccelerateDecelerateInterpolator());
                         } else Toast.makeText(getApplicationContext(),


### PR DESCRIPTION
UDP discovery was not being called while connected to server. This issues is
caused by different thread scheduling across different Android versions.

http://stackoverflow.com/questions/9119627/android-sdk-asynctask-doinbackground-not-running-subclass